### PR TITLE
Fixed bug with UV-switches and added alarm_motion exclude option

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -151,5 +151,8 @@
   },
   "0.9.4": {
     "en": "Mutlisensors with main capabilities set for either for Humidity and Motion"
+  },
+  "1.0.0": {
+    "en": "Fixed bug in floorheters and UV Switches. Added possibility to exclude motion from multisensors"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.github.alydersen.hdl-smartbus-homey",
-  "version": "0.9.4",
+  "version": "1.0.0",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "name": {

--- a/app.js
+++ b/app.js
@@ -177,22 +177,20 @@ class HDLSmartBus extends Homey.App {
     let senderType = signal.sender.type.toString();
 
     // Check for universal switch
-    if (dataFromSignal != undefined && dataFromSignal.switch != undefined) {
-      var foundType = 'universal-switch'
-    } else { // Look up the type in the device list
-      var foundType = await this._hdlDevicelist.typeOfDevice(senderType);  
+    var uvactivated = dataFromSignal != undefined && dataFromSignal.switch != undefined;
+    var foundType = await this._hdlDevicelist.typeOfDevice(senderType);  
+
+    if (uvactivated) {
+      await this._updateDevice("universal-switch", signal);
     }
 
     // Return if no type was found
     if (foundType == null) return;
 
     switch (foundType) {
-      case "universal-switch":
-        await this._updateDevice(foundType, signal);
-        break;
 
       case 'curtain':
-        this._hdlFoundUnits["curtain"][signal.sender.id] = signal.sender;
+        this._hdlFoundUnits[foundType][signal.sender.id] = signal.sender;
         // This driver allows failing signal.data, as it adds to the HDL library
         await this._updateDevice(foundType, signal);
         break;

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.github.alydersen.hdl-smartbus-homey",
-  "version": "0.9.4",
+  "version": "1.0.0",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "name": {

--- a/drivers/multisensor/driver.js
+++ b/drivers/multisensor/driver.js
@@ -26,9 +26,12 @@ class MultisensorDriver extends Homey.Driver {
     if (typeof homeyDevice === 'undefined') return;
     if (homeyDevice instanceof Error) return;
 
+    // Get the exclude list
+    let devicelist = new HdlDevicelist();
+    let exclude = await devicelist.mainCapability(signal.sender.type.toString());
 
     // Either this comes from a signal.motion or through universal switch
-    if (signal.data.movement != undefined) {
+    if (signal.data.movement != undefined && !exclude.includes("alarm_motion")) {
       await this.checkCapabilityAdded(homeyDevice, "alarm_motion");
       homeyDevice
         .setCapabilityValue("alarm_motion", signal.data.movement)
@@ -37,7 +40,8 @@ class MultisensorDriver extends Homey.Driver {
     if (
       signal.data.switch != undefined &&
       signal.data.switch ==
-        parseInt(this.homey.settings.get("hdl_universal_motion"))
+        parseInt(this.homey.settings.get("hdl_universal_motion")) &&
+        !exclude.includes("alarm_motion")
     ) {
       await this.checkCapabilityAdded(homeyDevice, "alarm_motion");
       homeyDevice

--- a/hdl/hdl_devicelist.js
+++ b/hdl/hdl_devicelist.js
@@ -22,12 +22,6 @@ class HdlTypelist {
         return this.list[id].main_capability;
     }
 
-    async getDict(id) {
-        if (this.list[id] == undefined) return null;
-
-        return this.list[id];
-    }
-
     get list() {
         return {
             "16": { type: "dimmer", channels: 48 },
@@ -49,24 +43,24 @@ class HdlTypelist {
             "210": { type: "floorheater", channels: 6 },
             "211": { type: "floorheater", channels: 6 },
             "212": { type: "floorheater", channels: 6 },
-            "305": { type: "multisensor", main_capability: "alarm_motion"},
-            "307": { type: "multisensor", main_capability: "alarm_motion"},
-            "308": { type: "multisensor", main_capability: "alarm_motion"},
-            "309": { type: "multisensor", main_capability: "alarm_motion"},
-            "310": { type: "multisensor", main_capability: "measure_humidity"},
-            "312": { type: "multisensor", main_capability: "alarm_motion"},
-            "314": { type: "multisensor", main_capability: "alarm_motion"},
-            "315": { type: "multisensor", main_capability: "alarm_motion"},
-            "316": { type: "multisensor", main_capability: "alarm_motion"},
-            "318": { type: "multisensor", main_capability: "alarm_motion"},
-            "321": { type: "multisensor", main_capability: "alarm_motion"},
-            "322": { type: "multisensor", main_capability: "alarm_motion"},
-            "328": { type: "multisensor", main_capability: "alarm_motion"},
-            "329": { type: "multisensor", main_capability: "alarm_motion"},
-            "330": { type: "multisensor", main_capability: "alarm_motion"},
-            "336": { type: "multisensor", main_capability: "alarm_motion"},
-            "337": { type: "multisensor", main_capability: "alarm_motion"},
-            "340": { type: "multisensor", main_capability: "alarm_motion"},
+            "305": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "307": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "308": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "309": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "310": { type: "multisensor", main_capability: "measure_humidity", exclude: ["alarm_motion"]},
+            "312": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "314": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "315": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "316": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "318": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "321": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "322": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "328": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "329": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "330": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "336": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "337": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
+            "340": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
             "363": { type: "relay", channels: 6 },
             "423": { type: "relay", channels: 4 },
             "425": { type: "relay", channels: 6 },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.github.alydersen.homey-smartbus",
-  "version": "0.9.4",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "com.github.alydersen.homey-smartbus",
-      "version": "0.9.4",
+      "version": "1.0.0",
       "dependencies": {
         "smart-bus": "^0.6.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.alydersen.homey-smartbus",
-  "version": "0.9.4",
+  "version": "1.0.0",
   "main": "app.js",
   "devDependencies": {
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.1"


### PR DESCRIPTION
When a signal included a universal switch, it would stop at trying to see it as an individual driver. This is fixed in this PR.

Also, added possibility to exclude alarm_motion on multisensors