### PR TITLE
Adding temperature sensor to HDL-MSP02.4C. Upgrades

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -199,5 +199,8 @@
   },
   "1.2.2": {
     "en": "Added a panel and some relays, and removed donate function"
+  },
+  "1.2.3": {
+    "en": "Adding temperature sensors to the HDL-MSP02.4C device"
   }
 }

--- a/.homeycompose/app.json
+++ b/.homeycompose/app.json
@@ -1,6 +1,6 @@
 {
   "id": "com.github.alydersen.hdl-smartbus-homey",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "name": {

--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "com.github.alydersen.hdl-smartbus-homey",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "name": {

--- a/hdl/hdl_devicelist.js
+++ b/hdl/hdl_devicelist.js
@@ -101,7 +101,7 @@ class HdlTypelist {
             "318": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
             "321": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
             "322": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
-            "323": { type: "multisensor", main_capability: "alarm_motion", exclude: ["measure_humidity", "measure_temperature"]},
+            "323": { type: "multisensor", main_capability: "alarm_motion", exclude: ["measure_humidity"]},
             "327": { type: "multisensor", main_capability: "alarm_motion", exclude: ["measure_humidity", "measure_temperature"]},
             "328": { type: "multisensor", main_capability: "alarm_motion", exclude: []},
             "329": { type: "multisensor", main_capability: "alarm_motion", exclude: []},

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "com.github.alydersen.homey-smartbus",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "com.github.alydersen.homey-smartbus",
-      "version": "1.2.2",
+      "version": "1.2.3",
       "dependencies": {
         "smart-bus": "^0.6.0"
       },
@@ -16,10 +16,11 @@
     },
     "node_modules/@types/homey": {
       "name": "homey-apps-sdk-v3-types",
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.5.tgz",
-      "integrity": "sha512-AH7UPiPILITBmjDSAnupLp2kaBO9GuAj5y0hk9tLC2mO0AuOQuRYnbXIxrHOG3kium8m99FnS3BUHg0aY/SNCg==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/homey-apps-sdk-v3-types/-/homey-apps-sdk-v3-types-0.3.10.tgz",
+      "integrity": "sha512-vkoDgPoDsVIK+Am/5rNIa32hVB3q7vlTCD2ECZ2Qd8XAHfoKU3yETaXsP5+owrHQGJ+Gw7C/J54Ae2yQAlOAyQ==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@types/node": "^14.14.20"
       }
@@ -28,17 +29,20 @@
       "version": "14.18.63",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
       "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/crc": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
-      "integrity": "sha512-wcAOOnkzlwFAlFCCF20ZAiGn25JgSBy+oQrdOeszuk0bxI2nc29YFFmlCbDEfZJJljuw4XVqHrGV34J89910yA=="
+      "integrity": "sha512-wcAOOnkzlwFAlFCCF20ZAiGn25JgSBy+oQrdOeszuk0bxI2nc29YFFmlCbDEfZJJljuw4XVqHrGV34J89910yA==",
+      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -46,12 +50,14 @@
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/smart-bus": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/smart-bus/-/smart-bus-0.6.0.tgz",
       "integrity": "sha512-KlWg7YE+aZC06wrMwPZqwfkldPhPvPohx9+cF9nqN6diGOGwlf9H2C6IRgjaljt3v1WAjtn0WboqTFpLNZEBMQ==",
+      "license": "MIT",
       "dependencies": {
         "crc": "~3.4",
         "debug": "~2.6"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.github.alydersen.homey-smartbus",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "main": "app.js",
   "devDependencies": {
     "@types/homey": "npm:homey-apps-sdk-v3-types@^0.3.1"


### PR DESCRIPTION
This pull request includes updates to add temperature sensor functionality to the HDL-MSP02.4C device and other related modifications. The most important changes are listed below:

### Feature Addition:
* [`.homeychangelog.json`](diffhunk://#diff-2faed226ecc24ec1740c5215be47707ad775144a743f63a848925eaf4ea83cf7R202-R204): Added a new entry for version 1.2.3 to document the addition of temperature sensors to the HDL-MSP02.4C device.

### Version Updates:
* [`.homeycompose/app.json`](diffhunk://#diff-d687a679fb9dfb7889441014c1ba29251b9ffd8e449fe15cc17a7361bbb336e5L3-R3): Updated the version from 1.2.2 to 1.2.3 to reflect the new changes.
* [`app.json`](diffhunk://#diff-96677aa35debfefd031d9d34d9c70369754ee3acb2d9a9d4090e98612efee6f5L4-R4): Updated the version from 1.2.2 to 1.2.3 to match the source file.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from 1.2.2 to 1.2.3 to ensure consistency across the project.

### Device Configuration:
* [`hdl/hdl_devicelist.js`](diffhunk://#diff-c483d55daa9ed879652483d96b00c8c5760eef143c2e23f08b06bf41bce2d019L104-R104): Modified the configuration for device type `323` to include temperature measurement by removing "measure_temperature" from the exclude list.